### PR TITLE
warn about ufw rules (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ and
 
 - `roles\nextcloud_config\defaults\main.yml` for nextcloud settings
 
+Also if you are working on a remote computer through ssh be sure to check the **firewall settings** in `roles/prep_ufw/defaults/main.yml` Only ports 22,80,443 will be opened by default. Please test locally before deploying on your remote (ssh) server, you will get locked out if you use a custom port.
+
 ## Remove Nextcloud
 
 If you want to get rid of the containers run the following command.


### PR DESCRIPTION
* warn about ufw rules blocking remote connection after deployment

I have not payed attention to the firewall settings and locked myself out of my remote computer. SSH is not accessible anymore because ufw is blocking the connection. It would be worth mentioning this behavior and warn other users.

* update Typo Port 20