### PR TITLE
Extracontainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ and
 
 Also if you are working on a remote computer through ssh be sure to check the **firewall settings** in `roles/prep_ufw/defaults/main.yml` Only ports 22,80,443 will be opened by default. Please test locally before deploying on your remote (ssh) server, you will get locked out if you use a custom port.
 
+### Serving web apps in other containers on the server
+
+If you have other containers serving apps on your server and wish to use the Traefik2-container created by this playbook as a reverse proxy for them take a look [routing other containers to traefik](docker/routing-other-containers-to-traefik.md). There is also a [sample config](./docker/docker-compose-whoami.yml).
+
 ## Remove Nextcloud
 
 If you want to get rid of the containers run the following command.

--- a/docker/docker-compose-whoami.yml
+++ b/docker/docker-compose-whoami.yml
@@ -1,0 +1,21 @@
+version: '3'
+
+networks:
+  traefik:
+    external: true
+services:
+  whoami:
+    image: traefik/whoami
+    networks:
+       - traefik
+    labels:
+      - traefik.enable=true
+      - traefik.http.middlewares.whoami-https.redirectscheme.scheme=https
+      - traefik.http.routers.whoami-http.entrypoints=web
+      - traefik.http.routers.whoami-http.rule=Host(`whoami.example.com`)
+      - traefik.http.routers.whoami-http.middlewares=whoami-https@docker
+      - traefik.http.routers.whoami.entrypoints=web-secure
+      - traefik.http.routers.whoami.rule=Host(`whoami.example.com`)
+      - traefik.http.routers.whoami.tls=true
+      - traefik.http.routers.whoami.tls.certresolver=certificatesResolverDefault
+      - traefik.docker.network=traefik

--- a/docker/routing-other-containers-to-traefik.md
+++ b/docker/routing-other-containers-to-traefik.md
@@ -53,6 +53,7 @@ becomes
 
 You cannot have more than one container with the same rule name.
 
+## Sample config
 Check out the sample [docker-compose-whoami.yml](docker-compose-whoami.yml) for traefik/whoami
 
 ## Credits

--- a/docker/routing-other-containers-to-traefik.md
+++ b/docker/routing-other-containers-to-traefik.md
@@ -1,0 +1,60 @@
+# Setup routes to other containers
+## Intro
+After setting up *nextcloud_on_docker* on your server you might want to route traffic to other containers or web-apps you might have on your server.  
+You can easily achieve this by using the **Traefik2** container ansible created. [Docs here](https://doc.traefik.io/traefik/v2.0/)  
+Using this method, *Traefik2* will take care of automatic request and management of SSL-Certificates.
+
+In the example below we will use the **[whoami](https://doc.traefik.io/traefik/v2.0/user-guides/docker-compose/basic-example/)** container. If you setup everything just right, when accessing `subdomain.fqdn.com` you will get information regarding IP, container name, etc. from the *whoami* container
+
+ 1. Create `docker-compose.yml` file with the sample content below. 
+>
+    version: '3'
+        networks:
+            traefik:
+                external: true
+        services:
+            whoami:
+                #A container that exposes an API to show its IP address
+                image: traefik/whoami
+                networks:
+                   #your container needs to be on the same network as traefik
+                   - traefik
+                labels:
+                  #enable traefik for this container
+                  - traefik.enable=true
+                  #create a middleware for whoami to redirect traffic to https
+                  - traefik.http.middlewares.whoami-https.redirectscheme.scheme=https
+                  #create a router called whoami-http to listen on the entrypoint for http/80. 
+                  #web is defined in traefik.yaml.j2
+                  - traefik.http.routers.whoami-http.entrypoints=web
+                  #set the domainname for the site on router whoami-http. It listens on http/80
+                  - traefik.http.routers.whoami-http.rule=Host(`subdomain.fqdn.com`)
+                  #route traffic from whoami-http to whoami-https middleware
+                  - traefik.http.routers.whoami-http.middlewares=whoami-https@docker
+                  #setup the entrypoint for https/443. Create a router called whoami.
+                  - traefik.http.routers.whoami.entrypoints=web-secure
+                  #define the domainname for this route. It listens on https/443
+                  - traefik.http.routers.whoami.rule=Host(`subdomain.fqdn.com`)
+                  #use tls
+                  - traefik.http.routers.whoami.tls=true
+                  #use this if you have setup LetsEncrypt
+                  - traefik.http.routers.whoami.tls.certresolver=certificatesResolverDefault
+                  #use this if you have another certificate issuer. It should match the initial ansible setup in inventory, used to spin up nextcloud-docker
+                  #- traefik.http.routers.whoami.tls.certresolver=dnsChallenge
+                  #inform traefik about the network it should listen on- useful if you have more than one networks for your container
+                  - traefik.docker.network=traefik
+
+ 2. Change `subdomain.fqdn.com` to your own subdomain
+ 3. To use it with multiple hosted containers you need to replace *whoami* in **all** the labels above with another meaningful name. e.g.
+>traefik.http.middlewares.whoami-https.redirectscheme.scheme=https
+
+becomes
+>traefik.http.middlewares.yourwebappname-https.redirectscheme.scheme=https
+
+You cannot have more than one container with the same rule name.
+
+Check out the sample docker-compose.yml for traefik/whoami
+
+## Credits
+Credit goes to [Chris Wiegman](https://chriswiegman.com/2019/10/serving-your-docker-apps-with-https-and-traefik-2/).
+

--- a/docker/routing-other-containers-to-traefik.md
+++ b/docker/routing-other-containers-to-traefik.md
@@ -6,7 +6,7 @@ Using this method, *Traefik2* will take care of automatic request and management
 
 In the example below we will use the **[whoami](https://doc.traefik.io/traefik/v2.0/user-guides/docker-compose/basic-example/)** container. If you setup everything just right, when accessing `subdomain.fqdn.com` you will get information regarding IP, container name, etc. from the *whoami* container
 
- 1. Create `docker-compose.yml` file with the sample content below. 
+ 1. Create `docker-compose.yml` file with the sample content below. Or use [docker-compose-whoami.yml](docker-compose-whoami.yml)
 >
     version: '3'
         networks:
@@ -52,9 +52,6 @@ becomes
 >traefik.http.middlewares.yourwebappname-https.redirectscheme.scheme=https
 
 You cannot have more than one container with the same rule name.
-
-## Sample config
-Check out the sample [docker-compose-whoami.yml](docker-compose-whoami.yml) for traefik/whoami
 
 ## Credits
 Credit goes to [Chris Wiegman](https://chriswiegman.com/2019/10/serving-your-docker-apps-with-https-and-traefik-2/).

--- a/docker/routing-other-containers-to-traefik.md
+++ b/docker/routing-other-containers-to-traefik.md
@@ -53,7 +53,7 @@ becomes
 
 You cannot have more than one container with the same rule name.
 
-Check out the sample docker-compose.yml for traefik/whoami
+Check out the sample [docker-compose-whoami.yml](docker-compose-whoami.yml) for traefik/whoami
 
 ## Credits
 Credit goes to [Chris Wiegman](https://chriswiegman.com/2019/10/serving-your-docker-apps-with-https-and-traefik-2/).

--- a/docker/routing-other-containers-to-traefik.md
+++ b/docker/routing-other-containers-to-traefik.md
@@ -54,5 +54,5 @@ becomes
 You cannot have more than one container with the same rule name.
 
 ## Credits
-Credit goes to [Chris Wiegman](https://chriswiegman.com/2019/10/serving-your-docker-apps-with-https-and-traefik-2/).
+Based on the Tutorial from [Chris Wiegman](https://chriswiegman.com/2019/10/serving-your-docker-apps-with-https-and-traefik-2/).
 


### PR DESCRIPTION
I used this ansible playbook to get nextcloud with all your extras up and working. I however had other containers serving websites and apps on my server. In the past I used a hassle free nginx-container-proxy. I had to find a way to get it working with the traefik2-container created with your playbook.
Here is the explanation and a sample config to help other people as well.